### PR TITLE
feat: bundle Mojo runtime libs in wheels

### DIFF
--- a/hatch_mojo/config.py
+++ b/hatch_mojo/config.py
@@ -43,6 +43,7 @@ class HookConfig:
     clean_before_build: bool
     clean_after_build: bool
     skip_editable: bool
+    bundle_libs: bool
     build_dir: str
     include: tuple[str, ...]
     exclude: tuple[str, ...]
@@ -167,6 +168,7 @@ def parse_config(raw: dict[str, Any] | None, *, target_name: str) -> HookConfig:
             clean_before_build=_bool(raw.get("clean-before-build"), False),
             clean_after_build=_bool(raw.get("clean-after-build"), False),
             skip_editable=_bool(raw.get("skip-editable"), True),
+            bundle_libs=_bool(raw.get("bundle-libs"), True),
             build_dir=str(raw.get("build-dir") or "build/mojo"),
             include=include,
             exclude=exclude,
@@ -185,6 +187,7 @@ def parse_config(raw: dict[str, Any] | None, *, target_name: str) -> HookConfig:
         clean_before_build=_bool(raw.get("clean-before-build"), False),
         clean_after_build=_bool(raw.get("clean-after-build"), False),
         skip_editable=_bool(raw.get("skip-editable"), True),
+        bundle_libs=_bool(raw.get("bundle-libs"), True),
         build_dir=str(build_dir),
         include=include,
         exclude=exclude,

--- a/hatch_mojo/plugin.py
+++ b/hatch_mojo/plugin.py
@@ -14,6 +14,7 @@ from hatch_mojo.cleaning import clean_from_manifest, save_manifest
 from hatch_mojo.compiler import compile_job, discover_mojo
 from hatch_mojo.config import parse_config
 from hatch_mojo.planner import plan_jobs, plan_jobs_leveled
+from hatch_mojo.runtime import bundle_runtime_libs
 from hatch_mojo.types import BuildJob
 
 _SOURCE_LAYOUTS = ("", "src", "src/py")
@@ -102,6 +103,15 @@ class MojoBuildHook(BuildHookInterface[Any]):
                     self.app.display_warning(log)
                 else:
                     self.app.display_debug(log)
+
+        if config.bundle_libs:
+            bundled = bundle_runtime_libs(
+                root=root,
+                build_dir=config.build_dir,
+                jobs=planned,
+                mojo_bin=mojo_bin,
+            )
+            build_data.setdefault("force_include", {}).update(bundled)
 
         register_artifacts(root=root, build_data=build_data, jobs=planned, target_name=self.target_name)
         save_manifest(root, config.build_dir, [job.output_path for job in planned])

--- a/hatch_mojo/runtime.py
+++ b/hatch_mojo/runtime.py
@@ -1,0 +1,159 @@
+"""Mojo runtime library discovery, bundling, and RPATH patching."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from hatch_mojo.types import BuildJob
+
+_RUNTIME_LIB_BASES: tuple[str, ...] = (
+    "KGENCompilerRTShared",
+    "AsyncRTRuntimeGlobals",
+    "MSupportGlobals",
+    "NVPTX",
+    "AsyncRTMojoBindings",
+)
+
+_SENTINEL = "libKGENCompilerRTShared.so"
+
+
+def _lib_filename(base: str) -> str:
+    """Return platform-appropriate shared library filename."""
+    if sys.platform == "darwin":
+        return f"lib{base}.dylib"
+    return f"lib{base}.so"
+
+
+def discover_modular_lib(root: Path, mojo_bin: str | None) -> Path:
+    """Find the ``modular/lib/`` directory containing Mojo runtime libraries.
+
+    Search order:
+    1. ``MODULAR_LIB_DIR`` environment variable
+    2. ``importlib.util.find_spec("modular")``
+    3. Walk up from the mojo binary
+    4. Well-known cibuildwheel container paths
+    """
+    env_dir = os.environ.get("MODULAR_LIB_DIR")
+    if env_dir:
+        path = Path(env_dir)
+        if (path / _SENTINEL).exists():
+            return path
+
+    spec = importlib.util.find_spec("modular")
+    if spec and spec.origin:
+        candidate = Path(spec.origin).parent / "lib"
+        if (candidate / _SENTINEL).exists():
+            return candidate
+
+    if mojo_bin:
+        cursor = Path(mojo_bin).resolve().parent
+        for _ in range(5):
+            candidate = cursor / "lib"
+            if (candidate / _SENTINEL).exists():
+                return candidate
+            if cursor.parent == cursor:
+                break
+            cursor = cursor.parent
+
+    for container_path in (
+        Path("/opt/modular/lib"),
+        root / ".modular" / "lib",
+    ):
+        if (container_path / _SENTINEL).exists():
+            return container_path
+
+    msg = (
+        "Could not locate Mojo runtime libraries (modular/lib). "
+        "Set MODULAR_LIB_DIR or ensure the modular package is importable."
+    )
+    raise FileNotFoundError(msg)
+
+
+def _compute_extension_rpath(module: str, pkg_name: str) -> str:
+    """Compute the RPATH for a python-extension based on its module depth.
+
+    ``mogemma._core`` (depth 1) → ``$ORIGIN:$ORIGIN/../mogemma.libs``
+    ``pkg.sub._core`` (depth 2) → ``$ORIGIN:$ORIGIN/../../pkg.libs``
+    """
+    origin = "@loader_path" if sys.platform == "darwin" else "$ORIGIN"
+    parts = module.split(".")
+    depth = len(parts) - 1
+    up = "/".join(".." for _ in range(depth))
+    return f"{origin}:{origin}/{up}/{pkg_name}.libs"
+
+
+def _patch_rpath(target: Path, rpath: str) -> None:
+    """Set RPATH on a shared library or extension."""
+    if sys.platform == "win32":
+        return
+    if sys.platform == "darwin":
+        subprocess.run(
+            ["install_name_tool", "-add_rpath", rpath, str(target)],  # noqa: S607
+            check=True,
+            capture_output=True,
+        )
+    else:
+        subprocess.run(
+            ["patchelf", "--set-rpath", rpath, str(target)],  # noqa: S607
+            check=True,
+            capture_output=True,
+        )
+
+
+def bundle_runtime_libs(
+    root: Path,
+    build_dir: str,
+    jobs: list[BuildJob],
+    mojo_bin: str | None,
+) -> dict[str, str]:
+    """Bundle Mojo runtime libs alongside python-extension outputs.
+
+    Returns a mapping of ``{staging_path: wheel_relative_path}`` suitable
+    for merging into Hatch ``force_include``.
+    """
+    if sys.platform == "win32":
+        return {}
+
+    ext_jobs = [j for j in jobs if j.emit == "python-extension" and j.module]
+    if not ext_jobs:
+        return {}
+
+    modular_lib = discover_modular_lib(root, mojo_bin)
+
+    # Group extension jobs by top-level package
+    packages: dict[str, list[BuildJob]] = {}
+    for job in ext_jobs:
+        pkg = job.module.split(".")[0]  # type: ignore[union-attr]
+        packages.setdefault(pkg, []).append(job)
+
+    force_include: dict[str, str] = {}
+    abs_build = root / build_dir
+
+    for pkg_name, pkg_jobs in packages.items():
+        libs_dir = abs_build / f"{pkg_name}.libs"
+        libs_dir.mkdir(parents=True, exist_ok=True)
+
+        for base in _RUNTIME_LIB_BASES:
+            filename = _lib_filename(base)
+            src = modular_lib / filename
+            if not src.exists():
+                msg = f"Missing required Mojo runtime library: {src}"
+                raise FileNotFoundError(msg)
+            dest = libs_dir / filename
+            shutil.copy2(src, dest)
+
+            origin = "@loader_path" if sys.platform == "darwin" else "$ORIGIN"
+            _patch_rpath(dest, origin)
+
+            force_include[str(dest)] = f"{pkg_name}.libs/{filename}"
+
+        for job in pkg_jobs:
+            rpath = _compute_extension_rpath(job.module, pkg_name)  # type: ignore[arg-type]
+            _patch_rpath(job.output_path, rpath)
+
+    return force_include

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -164,6 +164,41 @@ def test_parse_config_rejects_install_without_path() -> None:
         )
 
 
+def test_parse_config_bundle_libs_defaults_true() -> None:
+    config = parse_config(
+        {
+            "jobs": [
+                {
+                    "name": "core",
+                    "input": "src/mo/pkg/core.mojo",
+                    "emit": "python-extension",
+                    "module": "pkg._core",
+                }
+            ]
+        },
+        target_name="wheel",
+    )
+    assert config.bundle_libs is True
+
+
+def test_parse_config_bundle_libs_explicit_false() -> None:
+    config = parse_config(
+        {
+            "bundle-libs": False,
+            "jobs": [
+                {
+                    "name": "core",
+                    "input": "src/mo/pkg/core.mojo",
+                    "emit": "python-extension",
+                    "module": "pkg._core",
+                }
+            ],
+        },
+        target_name="wheel",
+    )
+    assert config.bundle_libs is False
+
+
 def test_parse_config_rejects_invalid_marker() -> None:
     with pytest.raises(InvalidMarker):
         parse_config(

--- a/tests/test_integration_wheel.py
+++ b/tests/test_integration_wheel.py
@@ -43,6 +43,7 @@ def test_wheel_build_includes_native_extension(tmp_path: Path) -> None:
         [tool.hatch.build.targets.wheel.hooks.mojo]
         targets = ["wheel"]
         mojo-bin = "{fake_mojo.as_posix()}"
+        bundle-libs = false
 
         [[tool.hatch.build.targets.wheel.hooks.mojo.jobs]]
         name = "core"

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -32,7 +32,13 @@ def _job(tmp_path: Path, *, name: str = "core") -> BuildJob:
     )
 
 
-def _config(*, parallel: bool = False, clean_before: bool = False, clean_after: bool = False) -> Any:
+def _config(
+    *,
+    parallel: bool = False,
+    clean_before: bool = False,
+    clean_after: bool = False,
+    bundle_libs: bool = True,
+) -> Any:
     return SimpleNamespace(
         jobs=(object(),),
         skip_editable=True,
@@ -42,6 +48,7 @@ def _config(*, parallel: bool = False, clean_before: bool = False, clean_after: 
         parallel=parallel,
         fail_fast=True,
         mojo_bin=None,
+        bundle_libs=bundle_libs,
     )
 
 
@@ -83,6 +90,7 @@ def test_initialize_serial_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path)
     seq: list[str] = []
     monkeypatch.setattr("hatch_mojo.plugin.clean_from_manifest", lambda *_args, **_kwargs: seq.append("clean"))
     monkeypatch.setattr("hatch_mojo.plugin.compile_job", lambda **_kwargs: (True, "ok"))
+    monkeypatch.setattr("hatch_mojo.plugin.bundle_runtime_libs", lambda **_kwargs: {})
     monkeypatch.setattr("hatch_mojo.plugin.register_artifacts", lambda **_kwargs: seq.append("register"))
     monkeypatch.setattr("hatch_mojo.plugin.save_manifest", lambda *_args, **_kwargs: seq.append("save"))
 
@@ -104,6 +112,7 @@ def test_initialize_parallel_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Pat
     monkeypatch.setattr("hatch_mojo.plugin.parse_config", lambda *_args, **_kwargs: _config(parallel=True))
     monkeypatch.setattr("hatch_mojo.plugin.plan_jobs_leveled", lambda *_args, **_kwargs: [jobs])
     monkeypatch.setattr("hatch_mojo.plugin.discover_mojo", lambda *_args, **_kwargs: "mojo")
+    monkeypatch.setattr("hatch_mojo.plugin.bundle_runtime_libs", lambda **_kwargs: {})
     monkeypatch.setattr("hatch_mojo.plugin.register_artifacts", lambda **_kwargs: None)
     monkeypatch.setattr("hatch_mojo.plugin.save_manifest", lambda *_args, **_kwargs: None)
 
@@ -174,6 +183,7 @@ def test_initialize_editable_copies_artifacts(monkeypatch: pytest.MonkeyPatch, t
     monkeypatch.setattr("hatch_mojo.plugin.plan_jobs", lambda *_args, **_kwargs: [job])
     monkeypatch.setattr("hatch_mojo.plugin.discover_mojo", lambda *_args, **_kwargs: "mojo")
     monkeypatch.setattr("hatch_mojo.plugin.compile_job", lambda **_kwargs: (True, "ok"))
+    monkeypatch.setattr("hatch_mojo.plugin.bundle_runtime_libs", lambda **_kwargs: {})
     monkeypatch.setattr("hatch_mojo.plugin.register_artifacts", lambda **_kwargs: None)
     monkeypatch.setattr("hatch_mojo.plugin.save_manifest", lambda *_args, **_kwargs: None)
 
@@ -181,6 +191,58 @@ def test_initialize_editable_copies_artifacts(monkeypatch: pytest.MonkeyPatch, t
     copied = pkg_dir / "_core.so"
     assert copied.exists()
     assert copied.read_text(encoding="utf-8") == "fake-binary"
+
+
+def test_initialize_calls_bundle_when_enabled(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    warnings: list[str] = []
+    debugs: list[str] = []
+    app = SimpleNamespace(display_warning=warnings.append, display_debug=debugs.append)
+    fake = SimpleNamespace(root=str(tmp_path), config={}, target_name="wheel", app=app)
+    job = _job(tmp_path)
+    monkeypatch.setattr("hatch_mojo.plugin.parse_config", lambda *_args, **_kwargs: _config(bundle_libs=True))
+    monkeypatch.setattr("hatch_mojo.plugin.plan_jobs", lambda *_args, **_kwargs: [job])
+    monkeypatch.setattr("hatch_mojo.plugin.discover_mojo", lambda *_args, **_kwargs: "mojo")
+    monkeypatch.setattr("hatch_mojo.plugin.compile_job", lambda **_kwargs: (True, "ok"))
+    monkeypatch.setattr("hatch_mojo.plugin.register_artifacts", lambda **_kwargs: None)
+    monkeypatch.setattr("hatch_mojo.plugin.save_manifest", lambda *_args, **_kwargs: None)
+
+    bundle_called = {"yes": False}
+
+    def _fake_bundle(**_kwargs: Any) -> dict[str, str]:
+        bundle_called["yes"] = True
+        return {"/tmp/staged.so": "pkg.libs/libFoo.so"}
+
+    monkeypatch.setattr("hatch_mojo.plugin.bundle_runtime_libs", _fake_bundle)
+
+    build_data: dict[str, Any] = {}
+    MojoBuildHook.initialize(cast("Any", fake), "standard", build_data)
+    assert bundle_called["yes"] is True
+    assert build_data["force_include"]["/tmp/staged.so"] == "pkg.libs/libFoo.so"
+
+
+def test_initialize_skips_bundle_when_disabled(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    warnings: list[str] = []
+    debugs: list[str] = []
+    app = SimpleNamespace(display_warning=warnings.append, display_debug=debugs.append)
+    fake = SimpleNamespace(root=str(tmp_path), config={}, target_name="wheel", app=app)
+    job = _job(tmp_path)
+    monkeypatch.setattr("hatch_mojo.plugin.parse_config", lambda *_args, **_kwargs: _config(bundle_libs=False))
+    monkeypatch.setattr("hatch_mojo.plugin.plan_jobs", lambda *_args, **_kwargs: [job])
+    monkeypatch.setattr("hatch_mojo.plugin.discover_mojo", lambda *_args, **_kwargs: "mojo")
+    monkeypatch.setattr("hatch_mojo.plugin.compile_job", lambda **_kwargs: (True, "ok"))
+    monkeypatch.setattr("hatch_mojo.plugin.register_artifacts", lambda **_kwargs: None)
+    monkeypatch.setattr("hatch_mojo.plugin.save_manifest", lambda *_args, **_kwargs: None)
+
+    bundle_called = {"yes": False}
+
+    def _fake_bundle(**_kwargs: Any) -> dict[str, str]:
+        bundle_called["yes"] = True
+        return {}
+
+    monkeypatch.setattr("hatch_mojo.plugin.bundle_runtime_libs", _fake_bundle)
+
+    MojoBuildHook.initialize(cast("Any", fake), "standard", {})
+    assert bundle_called["yes"] is False
 
 
 def test_clean_calls_clean_from_manifest(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from hatch_mojo.runtime import (
+    _RUNTIME_LIB_BASES,
+    _SENTINEL,
+    _compute_extension_rpath,
+    _lib_filename,
+    _patch_rpath,
+    bundle_runtime_libs,
+    discover_modular_lib,
+)
+from hatch_mojo.types import BuildJob
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _make_modular_lib(base: Path) -> Path:
+    """Create a fake modular/lib directory with the sentinel and all runtime libs."""
+    lib_dir = base / "lib"
+    lib_dir.mkdir(parents=True, exist_ok=True)
+    (lib_dir / _SENTINEL).write_bytes(b"")
+    for name in _RUNTIME_LIB_BASES:
+        (lib_dir / _lib_filename(name)).write_bytes(b"fake-lib")
+    return lib_dir
+
+
+def _ext_job(tmp_path: Path, *, module: str = "pkg._core", name: str = "core") -> BuildJob:
+    output = tmp_path / "build" / "mojo" / f"{name}.so"
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_bytes(b"fake-ext")
+    return BuildJob(
+        name=name,
+        input_path=tmp_path / f"{name}.mojo",
+        output_path=output,
+        emit="python-extension",
+        module=module,
+        install_kind=None,
+        install_path=None,
+        include_dirs=(),
+        defines=(),
+        flags=(),
+        env={},
+        depends_on=(),
+    )
+
+
+# ── _lib_filename ────────────────────────────────────────────────────────────
+
+
+def test_lib_filename_linux() -> None:
+    with patch.object(sys, "platform", "linux"):
+        assert _lib_filename("Foo") == "libFoo.so"
+
+
+def test_lib_filename_darwin() -> None:
+    with patch.object(sys, "platform", "darwin"):
+        assert _lib_filename("Foo") == "libFoo.dylib"
+
+
+# ── discover_modular_lib ────────────────────────────────────────────────────
+
+
+def test_discover_from_env_var(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    lib_dir = _make_modular_lib(tmp_path / "modular")
+    monkeypatch.setenv("MODULAR_LIB_DIR", str(lib_dir))
+    assert discover_modular_lib(tmp_path, None) == lib_dir
+
+
+def test_discover_from_importlib(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    modular_dir = tmp_path / "modular"
+    lib_dir = _make_modular_lib(modular_dir)
+    monkeypatch.delenv("MODULAR_LIB_DIR", raising=False)
+
+    fake_spec = SimpleNamespace(origin=str(modular_dir / "__init__.py"))
+    monkeypatch.setattr("hatch_mojo.runtime.importlib.util.find_spec", lambda _name: fake_spec)
+    assert discover_modular_lib(tmp_path, None) == lib_dir
+
+
+def test_discover_from_mojo_binary(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # modular/bin/mojo → modular/lib/
+    modular = tmp_path / "modular"
+    lib_dir = _make_modular_lib(modular)
+    bin_dir = modular / "bin"
+    bin_dir.mkdir(parents=True)
+    mojo_bin = bin_dir / "mojo"
+    mojo_bin.write_bytes(b"")
+
+    monkeypatch.delenv("MODULAR_LIB_DIR", raising=False)
+    monkeypatch.setattr("hatch_mojo.runtime.importlib.util.find_spec", lambda _name: None)
+    assert discover_modular_lib(tmp_path, str(mojo_bin)) == lib_dir
+
+
+def test_discover_from_container_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    lib_dir = _make_modular_lib(tmp_path / ".modular")
+    monkeypatch.delenv("MODULAR_LIB_DIR", raising=False)
+    monkeypatch.setattr("hatch_mojo.runtime.importlib.util.find_spec", lambda _name: None)
+    assert discover_modular_lib(tmp_path, None) == lib_dir
+
+
+def test_discover_not_found(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MODULAR_LIB_DIR", raising=False)
+    monkeypatch.setattr("hatch_mojo.runtime.importlib.util.find_spec", lambda _name: None)
+    with pytest.raises(FileNotFoundError, match="Could not locate Mojo runtime"):
+        discover_modular_lib(tmp_path, None)
+
+
+def test_discover_env_var_missing_sentinel(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Env var pointing to a dir without the sentinel is skipped."""
+    lib_dir = tmp_path / "fake" / "lib"
+    lib_dir.mkdir(parents=True)
+    monkeypatch.setenv("MODULAR_LIB_DIR", str(lib_dir))
+    monkeypatch.setattr("hatch_mojo.runtime.importlib.util.find_spec", lambda _name: None)
+    with pytest.raises(FileNotFoundError):
+        discover_modular_lib(tmp_path, None)
+
+
+# ── _compute_extension_rpath ────────────────────────────────────────────────
+
+
+def test_rpath_depth_1_linux() -> None:
+    with patch.object(sys, "platform", "linux"):
+        result = _compute_extension_rpath("mogemma._core", "mogemma")
+        assert result == "$ORIGIN:$ORIGIN/../mogemma.libs"
+
+
+def test_rpath_depth_2_linux() -> None:
+    with patch.object(sys, "platform", "linux"):
+        result = _compute_extension_rpath("pkg.sub._core", "pkg")
+        assert result == "$ORIGIN:$ORIGIN/../../pkg.libs"
+
+
+def test_rpath_depth_1_darwin() -> None:
+    with patch.object(sys, "platform", "darwin"):
+        result = _compute_extension_rpath("mogemma._core", "mogemma")
+        assert result == "@loader_path:@loader_path/../mogemma.libs"
+
+
+def test_rpath_depth_3() -> None:
+    with patch.object(sys, "platform", "linux"):
+        result = _compute_extension_rpath("a.b.c._core", "a")
+        assert result == "$ORIGIN:$ORIGIN/../../../a.libs"
+
+
+# ── _patch_rpath ─────────────────────────────────────────────────────────────
+
+
+def test_patch_rpath_linux(tmp_path: Path) -> None:
+    target = tmp_path / "lib.so"
+    target.write_bytes(b"")
+    with (
+        patch.object(sys, "platform", "linux"),
+        patch("hatch_mojo.runtime.subprocess.run") as mock_run,
+    ):
+        _patch_rpath(target, "$ORIGIN")
+        mock_run.assert_called_once_with(
+            ["patchelf", "--set-rpath", "$ORIGIN", str(target)],
+            check=True,
+            capture_output=True,
+        )
+
+
+def test_patch_rpath_darwin(tmp_path: Path) -> None:
+    target = tmp_path / "lib.dylib"
+    target.write_bytes(b"")
+    with (
+        patch.object(sys, "platform", "darwin"),
+        patch("hatch_mojo.runtime.subprocess.run") as mock_run,
+    ):
+        _patch_rpath(target, "@loader_path")
+        mock_run.assert_called_once_with(
+            ["install_name_tool", "-add_rpath", "@loader_path", str(target)],
+            check=True,
+            capture_output=True,
+        )
+
+
+def test_patch_rpath_windows_noop(tmp_path: Path) -> None:
+    target = tmp_path / "lib.dll"
+    target.write_bytes(b"")
+    with (
+        patch.object(sys, "platform", "win32"),
+        patch("hatch_mojo.runtime.subprocess.run") as mock_run,
+    ):
+        _patch_rpath(target, "anything")
+        mock_run.assert_not_called()
+
+
+# ── bundle_runtime_libs ─────────────────────────────────────────────────────
+
+
+def test_bundle_skips_on_windows(tmp_path: Path) -> None:
+    with patch.object(sys, "platform", "win32"):
+        result = bundle_runtime_libs(tmp_path, "build/mojo", [], None)
+        assert result == {}
+
+
+def test_bundle_skips_no_ext_jobs(tmp_path: Path) -> None:
+    non_ext = BuildJob(
+        name="lib",
+        input_path=tmp_path / "lib.mojo",
+        output_path=tmp_path / "lib.so",
+        emit="shared-lib",
+        module=None,
+        install_kind="force-include",
+        install_path="lib/",
+        include_dirs=(),
+        defines=(),
+        flags=(),
+        env={},
+        depends_on=(),
+    )
+    result = bundle_runtime_libs(tmp_path, "build/mojo", [non_ext], None)
+    assert result == {}
+
+
+def test_bundle_full_flow(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    modular = tmp_path / "modular"
+    _make_modular_lib(modular)
+    lib_dir = modular / "lib"
+    monkeypatch.setenv("MODULAR_LIB_DIR", str(lib_dir))
+
+    job = _ext_job(tmp_path, module="mogemma._core")
+
+    with (
+        patch.object(sys, "platform", "linux"),
+        patch("hatch_mojo.runtime.subprocess.run"),
+    ):
+        result = bundle_runtime_libs(tmp_path, "build/mojo", [job], None)
+
+    assert len(result) == len(_RUNTIME_LIB_BASES)
+    libs_dir = tmp_path / "build" / "mojo" / "mogemma.libs"
+    assert libs_dir.is_dir()
+
+    for base in _RUNTIME_LIB_BASES:
+        filename = f"lib{base}.so"
+        assert (libs_dir / filename).exists()
+        assert any(v == f"mogemma.libs/{filename}" for v in result.values())
+
+
+def test_bundle_multiple_packages(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    modular = tmp_path / "modular"
+    _make_modular_lib(modular)
+    monkeypatch.setenv("MODULAR_LIB_DIR", str(modular / "lib"))
+
+    job_a = _ext_job(tmp_path, module="pkga._core", name="a")
+    job_b = _ext_job(tmp_path, module="pkgb._core", name="b")
+
+    with (
+        patch.object(sys, "platform", "linux"),
+        patch("hatch_mojo.runtime.subprocess.run"),
+    ):
+        result = bundle_runtime_libs(tmp_path, "build/mojo", [job_a, job_b], None)
+
+    assert len(result) == len(_RUNTIME_LIB_BASES) * 2
+    assert any("pkga.libs/" in v for v in result.values())
+    assert any("pkgb.libs/" in v for v in result.values())
+
+
+def test_bundle_raises_on_missing_runtime_lib(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """If a runtime lib is missing from modular/lib, raise immediately."""
+    lib_dir = tmp_path / "modular" / "lib"
+    lib_dir.mkdir(parents=True)
+    # Create sentinel + only the first lib, but omit the rest
+    (lib_dir / _SENTINEL).write_bytes(b"")
+    (lib_dir / _lib_filename(_RUNTIME_LIB_BASES[0])).write_bytes(b"fake")
+    monkeypatch.setenv("MODULAR_LIB_DIR", str(lib_dir))
+
+    job = _ext_job(tmp_path)
+
+    with (
+        patch.object(sys, "platform", "linux"),
+        patch("hatch_mojo.runtime.subprocess.run"),
+        pytest.raises(FileNotFoundError, match="Missing required Mojo runtime"),
+    ):
+        bundle_runtime_libs(tmp_path, "build/mojo", [job], None)


### PR DESCRIPTION
## Summary

- Adds `bundle-libs` config option (default `true`) to `HookConfig` that bundles the 5 Mojo runtime shared libraries into `<pkg>.libs/` inside the wheel
- Creates `hatch_mojo/runtime.py` with modular/lib discovery (env var → importlib → mojo binary walk-up → container paths), library copying, and RPATH patching via `patchelf`/`install_name_tool`
- Wires bundling into the build hook between compilation and artifact registration, merging bundled libs into `force_include`

This fixes the `auditwheel repair` failure in cibuildwheel — the tool that stamps `manylinux_*` tags on wheels. Without bundling, the RPATH points to the build environment's `modular/lib` which auditwheel can't resolve, causing PyPI to reject the upload.

Closes #5