### PR TITLE
fix: robust macOS Mach-O patching and header padding

### DIFF
--- a/hatch_mojo/compiler.py
+++ b/hatch_mojo/compiler.py
@@ -46,6 +46,11 @@ def build_command(mojo_bin: str, root: Path, job: BuildJob) -> list[str]:
         command.extend(["-I", include_dir])
     for define in job.defines:
         command.extend(["-D", define])
+
+    if sys.platform == "darwin" and job.emit in {"python-extension", "shared-lib", "executable"}:
+        # Ensure we have enough Mach-O header space to run install_name_tool later
+        command.extend(["-Xlinker", "-headerpad_max_install_names"])
+
     command.extend([*job.flags, str(job.input_path.relative_to(root)), "-o", str(job.output_path.relative_to(root))])
     return command
 

--- a/hatch_mojo/runtime.py
+++ b/hatch_mojo/runtime.py
@@ -123,7 +123,6 @@ def _write_license_notice(
 _OTOOL_LIB_RE: re.Pattern[str] = re.compile(r"^\s+(.+?)\s+\(compatibility version")
 _LDD_LIB_RE: re.Pattern[str] = re.compile(r"^\s*(.+?)\s+=>\s+(.+?)\s+\(0x[0-9a-f]+\)")
 _LDD_LIB_ABS_RE: re.Pattern[str] = re.compile(r"^\s*(/.+?)\s+\(0x[0-9a-f]+\)")
-_OTOOL_RPATH_RE: re.Pattern[str] = re.compile(r"^\s+path\s+(.+?)(?:\s+\(offset .+\))?$")
 
 
 def _get_linked_libraries(target: Path) -> list[str]:
@@ -189,6 +188,23 @@ def _resolve_modular_dependencies(entry_point: Path, modular_lib: Path) -> set[s
     return seen
 
 
+def _run_install_name_tool(args: list[str], ignore_errors: list[str] | None = None) -> None:
+    """Run install_name_tool and handle idempotency and error reporting."""
+    try:
+        subprocess.run(
+            ["install_name_tool", *args],  # noqa: S607
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr or ""
+        if ignore_errors and any(msg in stderr for msg in ignore_errors):
+            return
+        msg = f"install_name_tool failed: {stderr}"
+        raise RuntimeError(msg) from exc
+
+
 def _strip_absolute_rpaths(target: Path) -> None:
     """Remove absolute RPATHs from a Mach-O binary.
 
@@ -204,30 +220,13 @@ def _strip_absolute_rpaths(target: Path) -> None:
         text=True,
     )
     for line in result.stdout.splitlines():
-        m = _OTOOL_RPATH_RE.match(line)
-        if m:
-            rpath = m.group(1)
-            if not rpath.startswith("@"):
-                subprocess.run(
-                    ["install_name_tool", "-delete_rpath", rpath, str(target)],  # noqa: S607
-                    check=True,
-                    capture_output=True,
+        if "path " in line:
+            rpath = line.split("path ")[1].split(" (offset")[0].strip()
+            if rpath and not rpath.startswith("@"):
+                _run_install_name_tool(
+                    ["-delete_rpath", rpath, str(target)],
+                    ignore_errors=["no LC_RPATH found"],
                 )
-
-
-def _has_rpath(target: Path, rpath: str) -> bool:
-    """Check whether *target* already contains the given LC_RPATH entry."""
-    result = subprocess.run(
-        ["otool", "-l", str(target)],  # noqa: S607
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    for line in result.stdout.splitlines():
-        m = _OTOOL_RPATH_RE.match(line)
-        if m and m.group(1) == rpath:
-            return True
-    return False
 
 
 def _resign_ad_hoc(target: Path) -> None:
@@ -258,11 +257,7 @@ def _patch_macos_dylibs(libs_dir: Path, lib_filenames: list[str]) -> None:
         # Strip residual absolute RPATHs from SDK build environment
         _strip_absolute_rpaths(target)
         # Change own identity
-        subprocess.run(
-            ["install_name_tool", "-id", f"@rpath/{filename}", str(target)],  # noqa: S607
-            check=True,
-            capture_output=True,
-        )
+        _run_install_name_tool(["-id", f"@rpath/{filename}", str(target)])
         # Rewrite sibling references
         linked = _get_linked_libraries(target)
         for ref in linked:
@@ -272,16 +267,8 @@ def _patch_macos_dylibs(libs_dir: Path, lib_filenames: list[str]) -> None:
                 continue
             basename = Path(ref).name
             if basename in lib_filenames:
-                subprocess.run(
-                    [  # noqa: S607
-                        "install_name_tool",
-                        "-change",
-                        ref,
-                        f"@rpath/{basename}",
-                        str(target),
-                    ],
-                    check=True,
-                    capture_output=True,
+                _run_install_name_tool(
+                    ["-change", ref, f"@rpath/{basename}", str(target)]
                 )
         _resign_ad_hoc(target)
 
@@ -296,24 +283,14 @@ def _patch_macos_extension(ext: Path, lib_filenames: list[str], rpaths: list[str
             continue
         basename = Path(ref).name
         if basename in lib_filenames:
-            subprocess.run(
-                [  # noqa: S607
-                    "install_name_tool",
-                    "-change",
-                    ref,
-                    f"@rpath/{basename}",
-                    str(ext),
-                ],
-                check=True,
-                capture_output=True,
+            _run_install_name_tool(
+                ["-change", ref, f"@rpath/{basename}", str(ext)]
             )
     for rpath in rpaths:
-        if not _has_rpath(ext, rpath):
-            subprocess.run(
-                ["install_name_tool", "-add_rpath", rpath, str(ext)],  # noqa: S607
-                check=True,
-                capture_output=True,
-            )
+        _run_install_name_tool(
+            ["-add_rpath", rpath, str(ext)],
+            ignore_errors=["already contains LC_RPATH"],
+        )
     _resign_ad_hoc(ext)
 
 
@@ -336,10 +313,9 @@ def _patch_rpath(target: Path, rpaths: list[str]) -> None:
         return
     if sys.platform == "darwin":
         for rpath in rpaths:
-            subprocess.run(
-                ["install_name_tool", "-add_rpath", rpath, str(target)],  # noqa: S607
-                check=True,
-                capture_output=True,
+            _run_install_name_tool(
+                ["-add_rpath", rpath, str(target)],
+                ignore_errors=["already contains LC_RPATH"],
             )
     else:
         subprocess.run(

--- a/hatch_mojo/runtime.py
+++ b/hatch_mojo/runtime.py
@@ -267,9 +267,7 @@ def _patch_macos_dylibs(libs_dir: Path, lib_filenames: list[str]) -> None:
                 continue
             basename = Path(ref).name
             if basename in lib_filenames:
-                _run_install_name_tool(
-                    ["-change", ref, f"@rpath/{basename}", str(target)]
-                )
+                _run_install_name_tool(["-change", ref, f"@rpath/{basename}", str(target)])
         _resign_ad_hoc(target)
 
 
@@ -283,9 +281,7 @@ def _patch_macos_extension(ext: Path, lib_filenames: list[str], rpaths: list[str
             continue
         basename = Path(ref).name
         if basename in lib_filenames:
-            _run_install_name_tool(
-                ["-change", ref, f"@rpath/{basename}", str(ext)]
-            )
+            _run_install_name_tool(["-change", ref, f"@rpath/{basename}", str(ext)])
     for rpath in rpaths:
         _run_install_name_tool(
             ["-add_rpath", rpath, str(ext)],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hatch-mojo"
-version = "0.1.7"
+version = "0.1.8"
 description = "Hatch build hook for compiling Mojo sources into Python and native artifacts"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -209,7 +209,7 @@ skip = "uv.lock"
 allow_dirty = true
 commit = false
 commit_args = "--no-verify"
-current_version = "0.1.7"
+current_version = "0.1.8"
 ignore_missing_files = false
 ignore_missing_version = false
 message = "chore(release): bump to `v{new_version}`"

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -13,13 +13,13 @@ import pytest
 from hatch_mojo.runtime import (
     _compute_extension_rpath,
     _get_linked_libraries,
-    _has_rpath,
     _lib_filename,
     _patch_macos_dylibs,
     _patch_macos_extension,
     _patch_rpath,
     _resign_ad_hoc,
     _resolve_modular_dependencies,
+    _run_install_name_tool,
     _sentinel,
     _strip_absolute_rpaths,
     _write_license_notice,
@@ -189,11 +189,13 @@ def test_patch_rpath_darwin(tmp_path: Path) -> None:
                 ["install_name_tool", "-add_rpath", "@loader_path", str(target)],
                 check=True,
                 capture_output=True,
+                text=True,
             ),
             call(
                 ["install_name_tool", "-add_rpath", "@loader_path/../pkg.libs", str(target)],
                 check=True,
                 capture_output=True,
+                text=True,
             ),
         ]
 
@@ -532,25 +534,31 @@ def test_strip_absolute_rpaths_preserves_at_paths(tmp_path: Path) -> None:
     assert len(mock_run.call_args_list) == 1
 
 
-# ── _has_rpath ──────────────────────────────────────────────────────────────
+# ── _run_install_name_tool ───────────────────────────────────────────────────
 
 
-def test_has_rpath_true(tmp_path: Path) -> None:
-    target = tmp_path / "ext.so"
-    target.write_bytes(b"")
-    mock_result = SimpleNamespace(stdout=_OTOOL_LOAD_COMMANDS)
+def test_run_install_name_tool_success() -> None:
+    with patch("hatch_mojo.runtime.subprocess.run") as mock_run:
+        _run_install_name_tool(["-add_rpath", "foo", "bar"])
+    mock_run.assert_called_once_with(
+        ["install_name_tool", "-add_rpath", "foo", "bar"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
 
-    with patch("hatch_mojo.runtime.subprocess.run", return_value=mock_result):
-        assert _has_rpath(target, "/opt/modular/lib") is True
+
+def test_run_install_name_tool_ignores_errors() -> None:
+    err = subprocess.CalledProcessError(1, [], stderr="already contains LC_RPATH")
+    with patch("hatch_mojo.runtime.subprocess.run", side_effect=err):
+        _run_install_name_tool(["-add_rpath", "foo", "bar"], ignore_errors=["already contains LC_RPATH"])
 
 
-def test_has_rpath_false(tmp_path: Path) -> None:
-    target = tmp_path / "ext.so"
-    target.write_bytes(b"")
-    mock_result = SimpleNamespace(stdout=_OTOOL_LOAD_COMMANDS)
-
-    with patch("hatch_mojo.runtime.subprocess.run", return_value=mock_result):
-        assert _has_rpath(target, "/nonexistent/path") is False
+def test_run_install_name_tool_raises_on_other_errors() -> None:
+    err = subprocess.CalledProcessError(1, [], stderr="some random error")
+    with patch("hatch_mojo.runtime.subprocess.run", side_effect=err):
+        with pytest.raises(RuntimeError, match="some random error"):
+            _run_install_name_tool(["-add_rpath", "foo", "bar"], ignore_errors=["already contains LC_RPATH"])
 
 
 # ── _patch_macos_dylibs ────────────────────────────────────────────────────
@@ -663,7 +671,6 @@ def test_patch_macos_extension_rewrites_refs_and_adds_rpath(tmp_path: Path) -> N
     with (
         patch("hatch_mojo.runtime.subprocess.run") as mock_run,
         patch("hatch_mojo.runtime._get_linked_libraries", return_value=linked),
-        patch("hatch_mojo.runtime._has_rpath", return_value=False),
     ):
         _patch_macos_extension(ext, lib_filenames, rpaths)
 
@@ -701,21 +708,25 @@ def test_patch_macos_extension_rewrites_refs_and_adds_rpath(tmp_path: Path) -> N
 
 
 def test_patch_macos_extension_skips_existing_rpath(tmp_path: Path) -> None:
-    """When the rpath already exists, -add_rpath is not called."""
+    """When the rpath already exists, the error is ignored."""
     ext = tmp_path / "_core.so"
     ext.write_bytes(b"")
     rpaths = ["@loader_path", "@loader_path/../mogemma.libs"]
 
+    def mock_run_side_effect(args, **kwargs):
+        if "-add_rpath" in args:
+            raise subprocess.CalledProcessError(1, args, stderr="already contains LC_RPATH")
+        return SimpleNamespace(stdout="")
+
     with (
-        patch("hatch_mojo.runtime.subprocess.run") as mock_run,
+        patch("hatch_mojo.runtime.subprocess.run", side_effect=mock_run_side_effect) as mock_run,
         patch("hatch_mojo.runtime._get_linked_libraries", return_value=[]),
-        patch("hatch_mojo.runtime._has_rpath", return_value=True),
     ):
         _patch_macos_extension(ext, ["libFoo.dylib"], rpaths)
 
-    # Only codesign should be called — no -add_rpath
-    assert mock_run.call_count == 1
-    assert mock_run.call_args_list[0].args[0] == [
+    # -add_rpath will be called twice and fail twice, plus one codesign call = 3 total calls.
+    assert mock_run.call_count == 3
+    assert mock_run.call_args_list[2].args[0] == [
         "codesign",
         "-s",
         "-",

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -556,9 +556,11 @@ def test_run_install_name_tool_ignores_errors() -> None:
 
 def test_run_install_name_tool_raises_on_other_errors() -> None:
     err = subprocess.CalledProcessError(1, [], stderr="some random error")
-    with patch("hatch_mojo.runtime.subprocess.run", side_effect=err):
-        with pytest.raises(RuntimeError, match="some random error"):
-            _run_install_name_tool(["-add_rpath", "foo", "bar"], ignore_errors=["already contains LC_RPATH"])
+    with (
+        patch("hatch_mojo.runtime.subprocess.run", side_effect=err),
+        pytest.raises(RuntimeError, match="some random error"),
+    ):
+        _run_install_name_tool(["-add_rpath", "foo", "bar"], ignore_errors=["already contains LC_RPATH"])
 
 
 # ── _patch_macos_dylibs ────────────────────────────────────────────────────

--- a/uv.lock
+++ b/uv.lock
@@ -383,7 +383,7 @@ wheels = [
 
 [[package]]
 name = "hatch-mojo"
-version = "0.1.7"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "hatchling" },


### PR DESCRIPTION
Refactors install_name_tool calls to be robust and idempotent, and injects header padding on macOS to prevent missing space errors.